### PR TITLE
Define file access path for storage:

### DIFF
--- a/amplify/auth/resource.ts
+++ b/amplify/auth/resource.ts
@@ -10,4 +10,5 @@ export const auth = defineAuth({
       verificationEmailSubject: "Welcome 👋 Verify your email!",
     },
   },
+  groups: ["admin"],
 });

--- a/amplify/storage/resource.ts
+++ b/amplify/storage/resource.ts
@@ -1,5 +1,11 @@
 import { defineStorage } from "@aws-amplify/backend";
 
 export const storage = defineStorage({
-  name: "artUploads",
+  name: "artApp",
+  access: (allow) => ({
+    "artUploads/*": [
+      allow.guest.to(["read"]),
+      allow.groups(["ADMIN"]).to(["read", "write", "delete"]),
+    ],
+  }),
 });


### PR DESCRIPTION
- Explicitly grant access by adding an access callback as a property within the options object passed to the defineStorage function in storage resource.ts The access callback returns an object where each key in the object is a file path and each value in the object is an array of access rules that apply to that path. (By default, no users or other project resources have access to any files in the storage bucket)

- Configure user groups when in your defineAuth object (in auth resource.ts), to scope storage access to specific groups (e.g. Admin)

ref:
https://docs.amplify.aws/nextjs/build-a-backend/storage/set-up-storage/#define-file-path-access https://docs.amplify.aws/nextjs/build-a-backend/storage/authorization/